### PR TITLE
fix : api patch시 순서가 바뀌는 문제 해결

### DIFF
--- a/src/main/java/sudols/ecopercent/repository/jpa/JpaItemRepository.java
+++ b/src/main/java/sudols/ecopercent/repository/jpa/JpaItemRepository.java
@@ -37,7 +37,7 @@ public class JpaItemRepository implements ItemRepository {
     @Override
     public List<Item> findListByIdAndCategory(Long userId, String category) {
         User user = findUserByUserId(userId);
-        return em.createQuery("select i from Item i where i.user = :user and i.category = :category")
+        return em.createQuery("select i from Item i where i.user = :user and i.category = :category ORDER BY i.id ASC")
                 .setParameter("user", user)
                 .setParameter("category", category)
                 .getResultList();

--- a/src/main/java/sudols/ecopercent/repository/jpa/JpaItemRepository.java
+++ b/src/main/java/sudols/ecopercent/repository/jpa/JpaItemRepository.java
@@ -37,7 +37,7 @@ public class JpaItemRepository implements ItemRepository {
     @Override
     public List<Item> findListByIdAndCategory(Long userId, String category) {
         User user = findUserByUserId(userId);
-        return em.createQuery("select i from Item i where i.user = :user and i.category = :category ORDER BY i.id ASC")
+        return em.createQuery("select i from Item i where i.user = :user and i.category = :category order by i.id asc")
                 .setParameter("user", user)
                 .setParameter("category", category)
                 .getResultList();


### PR DESCRIPTION
## 개요

db자체는 추가를 하거나 수정을 하면 맨 마지막으로 가는데 그것을 수정함

## 작업사항
db자체를 건들진 않고 return하는데 있어서 순서를 오름차순으로 내뱉게 하였다

## 변경로직
findListByIdAndCategory여기에 order by id를 추가


## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
