### PR TITLE
feat : 정확한 시간설정 기능

### DIFF
--- a/src/main/java/sudols/ecopercent/domain/Item.java
+++ b/src/main/java/sudols/ecopercent/domain/Item.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
+
 
 @Data
 @Entity

--- a/src/main/java/sudols/ecopercent/domain/Item.java
+++ b/src/main/java/sudols/ecopercent/domain/Item.java
@@ -3,6 +3,7 @@ package sudols.ecopercent.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 
@@ -47,7 +48,7 @@ public class Item {
     private Long currentUsageCount;
 
     @Column(name = "purchase_data")
-    private Date purchaseDate;
+    private LocalDate purchaseDate;
 
     // TODO: date 형식 정하는게 있는지 찾아보기. 어노테이션
     @Column(name = "registration_date")

--- a/src/main/java/sudols/ecopercent/domain/Item.java
+++ b/src/main/java/sudols/ecopercent/domain/Item.java
@@ -3,6 +3,7 @@ package sudols.ecopercent.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Data
@@ -50,10 +51,10 @@ public class Item {
 
     // TODO: date 형식 정하는게 있는지 찾아보기. 어노테이션
     @Column(name = "registration_date")
-    private Date registrationDate;
+    private LocalDateTime registrationDate;
 
     @Column(name = "latest_data")
-    private Date latestDate;
+    private LocalDateTime latestDate;
 
     private Boolean isTitle;
 }

--- a/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
@@ -22,4 +22,5 @@ public class CreateItemRequest {
     private Integer price;
 
     private LocalDate purchaseDate;
+
 }

--- a/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
@@ -1,8 +1,6 @@
 package sudols.ecopercent.dto.item;
 
 import lombok.Data;
-import sudols.ecopercent.domain.Item;
-import sudols.ecopercent.domain.User;
 
 import java.util.Date;
 

--- a/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/item/CreateItemRequest.java
@@ -2,7 +2,7 @@ package sudols.ecopercent.dto.item;
 
 import lombok.Data;
 
-import java.util.Date;
+import java.time.LocalDate;
 
 @Data
 public class CreateItemRequest {
@@ -21,5 +21,5 @@ public class CreateItemRequest {
 
     private Integer price;
 
-    private Date purchaseDate;
+    private LocalDate purchaseDate;
 }

--- a/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
+++ b/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
@@ -5,7 +5,6 @@ import lombok.Data;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Date;
 
 @Data
 @Builder
@@ -32,6 +31,7 @@ public class ItemResponse {
     private Long currentUsageCount;
 
     private LocalDate purchaseDate;
+
 
     private LocalDateTime registrationDate;
 

--- a/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
+++ b/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
@@ -3,6 +3,7 @@ package sudols.ecopercent.dto.item;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Data
@@ -31,9 +32,9 @@ public class ItemResponse {
 
     private Date purchaseDate;
 
-    private Date registrationDate;
+    private LocalDateTime registrationDate;
 
-    private Date latestDate;
+    private LocalDateTime latestDate;
 
     private Boolean isTitle;
 }

--- a/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
+++ b/src/main/java/sudols/ecopercent/dto/item/ItemResponse.java
@@ -3,6 +3,7 @@ package sudols.ecopercent.dto.item;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Date;
 
@@ -30,7 +31,7 @@ public class ItemResponse {
 
     private Long currentUsageCount;
 
-    private Date purchaseDate;
+    private LocalDate purchaseDate;
 
     private LocalDateTime registrationDate;
 

--- a/src/main/java/sudols/ecopercent/dto/item/UpdateItemRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/item/UpdateItemRequest.java
@@ -2,6 +2,7 @@ package sudols.ecopercent.dto.item;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.Date;
 
 @Data
@@ -16,5 +17,5 @@ public class UpdateItemRequest {
 
     private Integer price;
 
-    private Date purchaseDate;
+    private LocalDate purchaseDate;
 }

--- a/src/main/java/sudols/ecopercent/dto/item/UpdateItemRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/item/UpdateItemRequest.java
@@ -3,7 +3,6 @@ package sudols.ecopercent.dto.item;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Data
 public class UpdateItemRequest {

--- a/src/main/java/sudols/ecopercent/mapper/ItemMapper.java
+++ b/src/main/java/sudols/ecopercent/mapper/ItemMapper.java
@@ -9,6 +9,9 @@ public class ItemMapper {
 
     // TODO: 구현. 주어진 type 에 맞게 설정
     public Item createItemRequestToItem(CreateItemRequest request, User user) {
+        System.out.println(request.getPurchaseDate());
+        System.out.println(request.getPurchaseDate().getClass().getSimpleName());
+
         return Item.builder()
                 .user(user)
                 .image(request.getImage())

--- a/src/main/java/sudols/ecopercent/mapper/ItemMapper.java
+++ b/src/main/java/sudols/ecopercent/mapper/ItemMapper.java
@@ -9,9 +9,6 @@ public class ItemMapper {
 
     // TODO: 구현. 주어진 type 에 맞게 설정
     public Item createItemRequestToItem(CreateItemRequest request, User user) {
-        System.out.println(request.getPurchaseDate());
-        System.out.println(request.getPurchaseDate().getClass().getSimpleName());
-
         return Item.builder()
                 .user(user)
                 .image(request.getImage())

--- a/src/main/java/sudols/ecopercent/service/ItemServiceImpl.java
+++ b/src/main/java/sudols/ecopercent/service/ItemServiceImpl.java
@@ -126,6 +126,6 @@ public class ItemServiceImpl implements ItemService {
     }
 
     private LocalDateTime getKSTDateTime() {
-        return ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+        return ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime().withNano(0);
     }
 }

--- a/src/main/java/sudols/ecopercent/service/ItemServiceImpl.java
+++ b/src/main/java/sudols/ecopercent/service/ItemServiceImpl.java
@@ -12,6 +12,9 @@ import sudols.ecopercent.mapper.ItemMapper;
 import sudols.ecopercent.repository.ItemRepository;
 import sudols.ecopercent.repository.UserRepository;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -34,6 +37,7 @@ public class ItemServiceImpl implements ItemService {
         return userRepository.findById(createItemRequest.getUserId())
                 .map(user -> {
                     Item item = itemMapper.createItemRequestToItem(createItemRequest, user);
+                    item.setRegistrationDate(getKSTDateTime());
                     return itemRepository.save(item);
                 })
                 .map(itemMapper::itemToItemResponse).get();
@@ -67,6 +71,7 @@ public class ItemServiceImpl implements ItemService {
         return itemRepository.findById(itemId)
                 .map(item -> {
                     item.setCurrentUsageCount(item.getCurrentUsageCount() + 1);
+                    item.setLatestDate(getKSTDateTime());
                     return itemRepository.save(item);
                 })
                 .map(itemMapper::itemToItemResponse);
@@ -118,5 +123,9 @@ public class ItemServiceImpl implements ItemService {
 
     public void deleteAllItem() {
         itemRepository.deleteAll();
+    }
+
+    private LocalDateTime getKSTDateTime() {
+        return ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
 }


### PR DESCRIPTION
## 개요
아이템을 생성하거나, 아이템을 사용을 할 때 현재시간을 설정할 수 있게 만들었다
아이템 추가할 때 날짜 등록 가능

## 작업사항
getKSTDateTime() 추가
dto의 item, domain의 item에서 purchase_date 부분의 날짜 타입 수정


## 변경로직
createItem, increaseUsageCount 여기에 시간 설정 기능 추가
purchase_date Type Date => LocalDate


## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
