### PR TITLE
Ecopercent 408 백 kakao 로그인을 회의한 방식으로 변경

### DIFF
--- a/src/main/java/sudols/ecopercent/aop/ExceptionHandlers.java
+++ b/src/main/java/sudols/ecopercent/aop/ExceptionHandlers.java
@@ -1,0 +1,19 @@
+package sudols.ecopercent.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import sudols.ecopercent.exception.UserAlreadyExistsException;
+
+@Slf4j
+@ControllerAdvice
+public class ExceptionHandlers {
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<?> handleUserAlreadyExistsException(UserAlreadyExistsException e) {
+        log.debug("Handling exception: " + e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+    }
+}

--- a/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
+++ b/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
@@ -18,17 +18,9 @@ public class OAuth2Controller {
 
     private final KakaoOAuth2Service kakaoOAuth2Service;
 
-    @GetMapping("/code/kakao")
-    @ResponseBody
-    public void KakaoOAuthCallback(@RequestParam String code) {
-        System.out.println("code: " + code);
-    }
-
     @GetMapping("kakao")
     @ResponseBody
     public ResponseEntity<?> KakaoOAuthLogin(HttpServletRequest request, HttpServletResponse response) {
-        String code = request.getHeader("x-authorization-code");
-        System.out.println("code: " + code);
-        return kakaoOAuth2Service.kakaoOAuthLogin(response, code);
+        return kakaoOAuth2Service.kakaoOAuthLogin(request, response);
     }
 }

--- a/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
+++ b/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
@@ -1,5 +1,6 @@
 package sudols.ecopercent.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,15 @@ public class OAuth2Controller {
 
     @GetMapping("/code/kakao")
     @ResponseBody
-    public ResponseEntity<?> KakaoOAuthLogin(HttpServletResponse response, @RequestParam String code) {
+    public void KakaoOAuthCallback(@RequestParam String code) {
+        System.out.println("code: " + code);
+    }
+
+    @GetMapping("kakao")
+    @ResponseBody
+    public ResponseEntity<?> KakaoOAuthLogin(HttpServletRequest request, HttpServletResponse response) {
+        String code = request.getHeader("x-authorization-code");
+        System.out.println("code: " + code);
         return kakaoOAuth2Service.kakaoOAuthLogin(response, code);
     }
 }

--- a/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
+++ b/src/main/java/sudols/ecopercent/controller/OAuth2Controller.java
@@ -1,8 +1,8 @@
 package sudols.ecopercent.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +19,7 @@ public class OAuth2Controller {
 
     @GetMapping("/code/kakao")
     @ResponseBody
-    public void KakaoCallback(HttpServletRequest request, HttpServletResponse response, @RequestParam String code) {
-        kakaoOAuth2Service.handleOAuth2Callback(request, response, code);
+    public ResponseEntity<?> KakaoOAuthLogin(HttpServletResponse response, @RequestParam String code) {
+        return kakaoOAuth2Service.kakaoOAuthLogin(response, code);
     }
 }

--- a/src/main/java/sudols/ecopercent/controller/UserController.java
+++ b/src/main/java/sudols/ecopercent/controller/UserController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import sudols.ecopercent.dto.user.UpdateUserRequest;
@@ -25,8 +26,14 @@ public class UserController {
     @ResponseBody
     @ResponseStatus(code = HttpStatus.CREATED)
     public UserResponse CreateUser(HttpServletRequest request, HttpServletResponse response, @RequestBody CreateUserRequest createUserRequest) {
-        UserResponse userResponse = userService.createUser(request, response, createUserRequest);
-        return userResponse;
+        return userService.createUser(request, response, createUserRequest);
+    }
+
+    @GetMapping("/nicknames/{nickname}")
+    @ResponseBody
+    public ResponseEntity<?> checkNicknameExists(@PathVariable("nickname") String nickname) {
+        System.out.println("nickname: " + nickname);
+        return userService.isNicknameDuplicate(nickname);
     }
 
     @GetMapping("/users/{userId}")

--- a/src/main/java/sudols/ecopercent/dto/user/CreateUserRequest.java
+++ b/src/main/java/sudols/ecopercent/dto/user/CreateUserRequest.java
@@ -16,4 +16,6 @@ public class CreateUserRequest {
     private String email;
 
     private String profileImage;
+
+    private String profileMessage;
 }

--- a/src/main/java/sudols/ecopercent/exception/UserAlreadyExistsException.java
+++ b/src/main/java/sudols/ecopercent/exception/UserAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package sudols.ecopercent.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import sudols.ecopercent.domain.User;
+
+@Slf4j
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String email) {
+        super(email + " 은 이미 존재하는 유저입니다."); // TODO: 로그로 변경
+    }
+}

--- a/src/main/java/sudols/ecopercent/mapper/UserMapper.java
+++ b/src/main/java/sudols/ecopercent/mapper/UserMapper.java
@@ -13,6 +13,7 @@ public class UserMapper {
                 .nickname(request.getNickname())
                 .email(request.getEmail())
                 .profileImage(request.getProfileImage())
+                .profileMessage(request.getProfileMessage())
                 .build();
     }
 

--- a/src/main/java/sudols/ecopercent/repository/UserRepository.java
+++ b/src/main/java/sudols/ecopercent/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/sudols/ecopercent/repository/UserRepository.java
+++ b/src/main/java/sudols/ecopercent/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/sudols/ecopercent/security/JwtAuthenticationFilter.java
+++ b/src/main/java/sudols/ecopercent/security/JwtAuthenticationFilter.java
@@ -19,7 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = getTokenFromRequest(request);
+        String token = jwtTokenProvider.getTokenFromRequest(request);
         if (token != null && jwtTokenProvider.validateToken(token)) {
             String email = jwtTokenProvider.getEmailFromToken(token);
             Authentication authentication = new PreAuthenticatedAuthenticationToken(email, null);
@@ -29,13 +29,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
 
     }
-
-    private String getTokenFromRequest(HttpServletRequest request) {
-        String bearerToken = request.getHeader("Authorization");
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
-
 }

--- a/src/main/java/sudols/ecopercent/security/JwtTokenProvider.java
+++ b/src/main/java/sudols/ecopercent/security/JwtTokenProvider.java
@@ -7,16 +7,16 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import sudols.ecopercent.domain.User;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.IOException;
 import java.util.Date;
 
 @Component
@@ -40,10 +40,7 @@ public class JwtTokenProvider {
         this.key = new SecretKeySpec(keyBytes, SignatureAlgorithm.HS256.getJcaName());
     }
 
-    public void generateTokenAndRedirectHomeWithCookie(HttpServletRequest request, HttpServletResponse response, User user) {
-//        String referer = request.getHeader("Referer");
-        String referer = "http://localhost:3000/";
-
+    public ResponseEntity<?> generateTokenAndReturnResponseWithCookie(HttpServletResponse response, User user) {
         String accessToken = generateAccessToken(user.getEmail());
         String refreshToken = generateRefreshToken(user.getEmail());
 
@@ -59,12 +56,7 @@ public class JwtTokenProvider {
         response.addCookie(accessTokenCookie);
         response.addCookie(refreshTokenCookie);
         response.addCookie(useridCookie);
-
-        try {
-            response.sendRedirect(referer + "home");
-        } catch (IOException e) {
-            System.out.println("Failed redirection: " + e); // TODO: 구현. 예외처리
-        }
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     public String generateAccessToken(String email) {

--- a/src/main/java/sudols/ecopercent/security/JwtTokenProvider.java
+++ b/src/main/java/sudols/ecopercent/security/JwtTokenProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -107,5 +108,13 @@ public class JwtTokenProvider {
             System.out.println(e); // TODO: 로그
             return false;
         }
+    }
+
+    public String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/sudols/ecopercent/security/SecurityConfig.java
+++ b/src/main/java/sudols/ecopercent/security/SecurityConfig.java
@@ -29,6 +29,10 @@ public class SecurityConfig {
         http
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.GET, "/users").permitAll() // TODO: 삭제. TEST
+                        .requestMatchers(HttpMethod.DELETE, "/users").permitAll() // TODO: 삭제. TEST
+                        .requestMatchers(HttpMethod.GET, "/items/all").permitAll() // TODO: 삭제. TEST
+                        .requestMatchers(HttpMethod.DELETE, "/items").permitAll() // TODO: 삭제. TEST
                         .requestMatchers(HttpMethod.POST, "/users").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/sudols/ecopercent/service/UserService.java
+++ b/src/main/java/sudols/ecopercent/service/UserService.java
@@ -2,6 +2,7 @@ package sudols.ecopercent.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
 import sudols.ecopercent.domain.User;
 import sudols.ecopercent.dto.user.UpdateUserRequest;
 import sudols.ecopercent.dto.user.CreateUserRequest;
@@ -13,6 +14,8 @@ import java.util.Optional;
 public interface UserService {
 
     UserResponse createUser(HttpServletRequest request, HttpServletResponse response, CreateUserRequest createUserRequest);
+
+    ResponseEntity<?> isNicknameDuplicate(String nickname);
 
     Optional<UserResponse> getUser(Long userId);
 

--- a/src/main/java/sudols/ecopercent/service/UserServiceImpl.java
+++ b/src/main/java/sudols/ecopercent/service/UserServiceImpl.java
@@ -4,6 +4,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import sudols.ecopercent.domain.User;
 import sudols.ecopercent.dto.user.CreateUserRequest;
@@ -36,6 +39,16 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.save(userMapper.createUserRequestToUser(createUserRequest));
         jwtTokenProvider.generateTokenAndReturnResponseWithCookie(response, user);
         return userMapper.userToUserResponse(user);
+    }
+
+    @Override
+    public ResponseEntity<?> isNicknameDuplicate(String nickname) {
+        boolean isDuplicate = userRepository.existsByNickname(nickname);
+        if (isDuplicate) {
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
     }
 
     public Optional<UserResponse> getUser(Long userId) {

--- a/src/main/java/sudols/ecopercent/service/UserServiceImpl.java
+++ b/src/main/java/sudols/ecopercent/service/UserServiceImpl.java
@@ -1,22 +1,20 @@
 package sudols.ecopercent.service;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import sudols.ecopercent.domain.User;
 import sudols.ecopercent.dto.user.CreateUserRequest;
 import sudols.ecopercent.dto.user.UpdateUserRequest;
 import sudols.ecopercent.dto.user.UserResponse;
+import sudols.ecopercent.exception.UserAlreadyExistsException;
 import sudols.ecopercent.mapper.UserMapper;
 import sudols.ecopercent.repository.ItemRepository;
 import sudols.ecopercent.repository.UserRepository;
 import sudols.ecopercent.security.JwtTokenProvider;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,8 +30,11 @@ public class UserServiceImpl implements UserService {
 
     // TODO: 구현. 유저 생성 시 등록된 아이템을 대표 아이템으로 등록
     public UserResponse createUser(HttpServletRequest request, HttpServletResponse response, CreateUserRequest createUserRequest) {
+        if (userRepository.existsByEmail(createUserRequest.getEmail())) {
+            throw new UserAlreadyExistsException(createUserRequest.getEmail());
+        }
         User user = userRepository.save(userMapper.createUserRequestToUser(createUserRequest));
-        jwtTokenProvider.generateTokenAndRedirectHomeWithCookie(request, response, user);
+        jwtTokenProvider.generateTokenAndReturnResponseWithCookie(response, user);
         return userMapper.userToUserResponse(user);
     }
 

--- a/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
+++ b/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
@@ -1,14 +1,13 @@
 package sudols.ecopercent.service.auth2;
 
 import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 import sudols.ecopercent.domain.User;
 import sudols.ecopercent.dto.security.KakaoAccountResponse;
 import sudols.ecopercent.dto.security.KakaoUserDetail;
@@ -16,7 +15,6 @@ import sudols.ecopercent.dto.security.OAuth2AccessTokenResponse;
 import sudols.ecopercent.repository.UserRepository;
 import sudols.ecopercent.security.JwtTokenProvider;
 
-import java.io.IOException;
 import java.util.Optional;
 
 @Service
@@ -48,39 +46,21 @@ public class KakaoOAuth2Service implements OAuth2Service {
     private String userInfoAPI;
 
     @Override
-    public void handleOAuth2Callback(HttpServletRequest request, HttpServletResponse response, String code) {
-//        String referer = request.getHeader("Referer");
-        String referer = "http://localhost:3000/";
-        System.out.println("referer: " + referer);
-        String kakaoAccessToken = requestTokenByCode(code)
-                .blockOptional()
-                .map(ResponseEntity::getBody)
-                .map(OAuth2AccessTokenResponse::getAccessToken)
-                .orElseThrow(() -> new RuntimeException("Failed to retrieve access token"));
-        System.out.println("kakaoAccessToken: " + kakaoAccessToken);
-        KakaoUserDetail kakaoUserDetail = requestUserDetailByAccessToken(kakaoAccessToken)
-                .blockOptional()
-                .map(ResponseEntity::getBody)
-                .map(KakaoAccountResponse::getKakaoUserDetail)
-                .orElseThrow(() -> new RuntimeException("Failed to retrieve user detail"));
-        System.out.println("kakaoUserDetail: " + kakaoUserDetail);
+    public ResponseEntity<?> kakaoOAuthLogin(HttpServletResponse response, String code) {
+        String kakaoAccessToken = requestTokenByCode(code);
+        KakaoUserDetail kakaoUserDetail = requestUserDetailByAccessToken(kakaoAccessToken);
         String email = kakaoUserDetail.getEmail();
         Optional<User> optionalUser = userRepository.findByEmail(email);
-        if (optionalUser.isPresent()) {
-            jwtTokenProvider.generateTokenAndRedirectHomeWithCookie(request, response, optionalUser.get());
-        } else {
+        if (optionalUser.isEmpty()) {
             Cookie emailCookie = new Cookie("email", email);
             emailCookie.setPath("/signup");
             response.addCookie(emailCookie);
-            try {
-                response.sendRedirect(referer + "signup");
-            } catch (IOException e) {
-                System.out.println("Failed redirection: " + e); // TODO: 구현. 예외처리
-            }
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
+        return jwtTokenProvider.generateTokenAndReturnResponseWithCookie(response, optionalUser.get());
     }
 
-    private Mono<ResponseEntity<OAuth2AccessTokenResponse>> requestTokenByCode(String code) {
+    private String requestTokenByCode(String code) {
         return WebClient.create(kauthUri)
                 .post()
                 .uri(uriBuilder -> uriBuilder.path(tokenUri)
@@ -90,10 +70,14 @@ public class KakaoOAuth2Service implements OAuth2Service {
                         .queryParam("code", code)
                         .build())
                 .retrieve()
-                .toEntity(OAuth2AccessTokenResponse.class);
+                .toEntity(OAuth2AccessTokenResponse.class)
+                .blockOptional()
+                .map(ResponseEntity::getBody)
+                .map(OAuth2AccessTokenResponse::getAccessToken)
+                .orElseThrow(() -> new RuntimeException("Failed to retrieve access token"));
     }
 
-    private Mono<ResponseEntity<KakaoAccountResponse>> requestUserDetailByAccessToken(String accessToken) {
+    private KakaoUserDetail requestUserDetailByAccessToken(String accessToken) {
         WebClient client = WebClient.builder()
                 .baseUrl(kapiUri)
                 .defaultHeader("Authorization", "Bearer " + accessToken)
@@ -103,6 +87,10 @@ public class KakaoOAuth2Service implements OAuth2Service {
                 .uri(uriBuilder -> uriBuilder.path(userInfoAPI)
                         .build())
                 .retrieve()
-                .toEntity(KakaoAccountResponse.class);
+                .toEntity(KakaoAccountResponse.class)
+                .blockOptional()
+                .map(ResponseEntity::getBody)
+                .map(KakaoAccountResponse::getKakaoUserDetail)
+                .orElseThrow(() -> new RuntimeException("Failed to retrieve user detail"));
     }
 }

--- a/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
+++ b/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
@@ -12,10 +12,11 @@ import org.springframework.web.reactive.function.client.WebClient;
 import sudols.ecopercent.domain.User;
 import sudols.ecopercent.dto.security.KakaoAccountResponse;
 import sudols.ecopercent.dto.security.KakaoUserDetail;
-import sudols.ecopercent.dto.security.OAuth2AccessTokenResponse;
 import sudols.ecopercent.repository.UserRepository;
 import sudols.ecopercent.security.JwtTokenProvider;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 @Service
@@ -24,21 +25,6 @@ public class KakaoOAuth2Service implements OAuth2Service {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
-
-    @Value("${kakao.client-id}")
-    private String clientId;
-
-    @Value("${kakao.authorization-grant-type}")
-    private String grantType;
-
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
-    @Value("${kakao.kauth-uri}")
-    private String kauthUri;
-
-    @Value("${kakao.token-uri}")
-    private String tokenUri;
 
     @Value("${kakao.kapi-uri}")
     private String kapiUri;
@@ -49,14 +35,14 @@ public class KakaoOAuth2Service implements OAuth2Service {
     @Override
     public ResponseEntity<?> kakaoOAuthLogin(HttpServletRequest request, HttpServletResponse response) {
         String kakaoAccessToken = jwtTokenProvider.getTokenFromRequest(request);
+        System.out.println("kakaoAccessToken: " + kakaoAccessToken);
         KakaoUserDetail kakaoUserDetail = requestUserDetailByAccessToken(kakaoAccessToken);
         String email = kakaoUserDetail.getEmail();
         Optional<User> optionalUser = userRepository.findByEmail(email);
         if (optionalUser.isEmpty()) {
-            Cookie emailCookie = new Cookie("email", email);
-            emailCookie.setPath("/");
-            response.addCookie(emailCookie);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            Map<String, String> responseBody = new HashMap<>();
+            responseBody.put("email", email);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
         }
         return jwtTokenProvider.generateTokenAndReturnResponseWithCookie(response, optionalUser.get());
     }

--- a/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
+++ b/src/main/java/sudols/ecopercent/service/auth2/KakaoOAuth2Service.java
@@ -54,7 +54,7 @@ public class KakaoOAuth2Service implements OAuth2Service {
         Optional<User> optionalUser = userRepository.findByEmail(email);
         if (optionalUser.isEmpty()) {
             Cookie emailCookie = new Cookie("email", email);
-            emailCookie.setPath("/signup");
+            emailCookie.setPath("/");
             response.addCookie(emailCookie);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }

--- a/src/main/java/sudols/ecopercent/service/auth2/OAuth2Service.java
+++ b/src/main/java/sudols/ecopercent/service/auth2/OAuth2Service.java
@@ -6,5 +6,5 @@ import org.springframework.http.ResponseEntity;
 
 public interface OAuth2Service {
 
-    ResponseEntity<?> kakaoOAuthLogin(HttpServletResponse response, String code);
+    ResponseEntity<?> kakaoOAuthLogin(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/sudols/ecopercent/service/auth2/OAuth2Service.java
+++ b/src/main/java/sudols/ecopercent/service/auth2/OAuth2Service.java
@@ -2,8 +2,9 @@ package sudols.ecopercent.service.auth2;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
 
 public interface OAuth2Service {
 
-    void handleOAuth2Callback(HttpServletRequest request, HttpServletResponse response, String code);
+    ResponseEntity<?> kakaoOAuthLogin(HttpServletResponse response, String code);
 }


### PR DESCRIPTION
## 개요
- Kakao 로그인 방식을 회의한 방식으로 변경
- 닉네임 중복 API 구현
- 이미 존재하는 유저가 회원가입 시도할 때 예외처리

## 작업사항
- 각 커밋 확인

## 변경로직


## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
