### PR TITLE
fix: 유저 정보 업데이트에서 닉네임 중복 시 409 반환

### DIFF
--- a/src/main/java/sudols/ecopercent/service/UserService.java
+++ b/src/main/java/sudols/ecopercent/service/UserService.java
@@ -93,6 +93,9 @@ public class UserService {
     }
 
     public UserResponse updateUser(String email, UpdateUserRequest updateUserRequest, MultipartFile profileImageMultipartFile) {
+        if (userRepository.existsByNickname(updateUserRequest.getNickname())) {
+            throw new NicknameAlreadyExistsException(updateUserRequest.getNickname());
+        }
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserNotExistsException(email));
         BeanUtils.copyProperties(updateUserRequest, user);


### PR DESCRIPTION
fix: 유저 정보 업데이트에서 닉네임 중복 시 409 반환